### PR TITLE
Fix: Dates for season 2 episodes

### DIFF
--- a/content/episode/episode_s02e01.md
+++ b/content/episode/episode_s02e01.md
@@ -1,7 +1,7 @@
 +++
 Description = "Chris and Nick chat to Krysztof (Chris) Daniel about Strategy and Wardley Maps"
 Date = 2023-01-04T17:14:10Z
-PublishDate = 2023-01-04T17:14:10Z # this is the datetime for the when the epsiode was published. This will default to Date if it is not set. Example is "2016-04-25T04:09:45-05:00"
+PublishDate = 2023-01-15T13:24:00Z # this is the datetime for the when the epsiode was published. This will default to Date if it is not set. Example is "2016-04-25T04:09:45-05:00"
 podcast_file = "52390806/play.mp3" # the name of the podcast file, after the media prefix.
 podcast_duration = ""
 #podcast_bytes = "" # the length of the episode in bytes

--- a/content/episode/episode_s02e01.md
+++ b/content/episode/episode_s02e01.md
@@ -1,6 +1,6 @@
 +++
 Description = "Chris and Nick chat to Krysztof (Chris) Daniel about Strategy and Wardley Maps"
-Date = 2023-01-04T17:14:10Z
+Date = 2023-01-15T13:24:00Z
 PublishDate = 2023-01-15T13:24:00Z # this is the datetime for the when the epsiode was published. This will default to Date if it is not set. Example is "2016-04-25T04:09:45-05:00"
 podcast_file = "52390806/play.mp3" # the name of the podcast file, after the media prefix.
 podcast_duration = ""

--- a/content/episode/episode_s02e02.md
+++ b/content/episode/episode_s02e02.md
@@ -1,7 +1,7 @@
 +++
 Description = "Nick and Chris talk to Andy Ellis about using the right language with the business, and supporting how they manage risk."
 Date = 2023-01-04T17:14:35Z
-PublishDate = 2023-01-04T17:14:35Z # this is the datetime for the when the epsiode was published. This will default to Date if it is not set. Example is "2016-04-25T04:09:45-05:00"
+PublishDate = 2023-02-13T13:15:00Z # this is the datetime for the when the epsiode was published. This will default to Date if it is not set. Example is "2016-04-25T04:09:45-05:00"
 podcast_file = "52715904/play.mp3" # the name of the podcast file, after the media prefix.
 podcast_duration = ""
 #podcast_bytes = "" # the length of the episode in bytes

--- a/content/episode/episode_s02e02.md
+++ b/content/episode/episode_s02e02.md
@@ -1,6 +1,6 @@
 +++
 Description = "Nick and Chris talk to Andy Ellis about using the right language with the business, and supporting how they manage risk."
-Date = 2023-01-04T17:14:35Z
+Date = 2023-02-13T13:15:00Z
 PublishDate = 2023-02-13T13:15:00Z # this is the datetime for the when the epsiode was published. This will default to Date if it is not set. Example is "2016-04-25T04:09:45-05:00"
 podcast_file = "52715904/play.mp3" # the name of the podcast file, after the media prefix.
 podcast_duration = ""


### PR DESCRIPTION
Episodes for s02 were showing as being published on the dates when the episode files were created

**- What I did**

Changed the dates to match when the episodes were merged.

**- Description for the changelog**

Fix: Dates for season 2 episodes