### PR TITLE
feat: Update theme to enable Mastodon links

### DIFF
--- a/content/host/cswan.md
+++ b/content/host/cswan.md
@@ -1,6 +1,6 @@
 +++
 Title = "Chris Swan"
-Twitter = "cpswan"
+Mastodon = "https://hachyderm.io/@cpswan"
 Website = "https://chris.swanz.net/"
 Type = "host"
 Linkedin = "chrisswan"

--- a/themes/castanet/CHANGELOG.md
+++ b/themes/castanet/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.21.4](https://github.com/mattstratton/castanet/tree/1.21.4) (2023-04-17)
+
+## [1.21.3](https://github.com/mattstratton/castanet/tree/1.21.3) (2023-04-17)
+
+## [1.21.2](https://github.com/mattstratton/castanet/tree/1.21.2) (2023-04-17)
+
+## [1.21.1](https://github.com/mattstratton/castanet/tree/1.21.1) (2023-04-17)
+
+## [1.21.0](https://github.com/mattstratton/castanet/tree/1.21.0) (2023-04-17)
+
+## [1.20.0](https://github.com/mattstratton/castanet/tree/1.20.0) (2023-04-17)
+
+**Implemented enhancements:**
+
+- \[ENHANCEMENT\] - Add Mastodon to the Social options [\#392](https://github.com/mattstratton/castanet/issues/392)
+- \[ENHANCEMENT\] - Can we make an option to have youtube be a link on the main page just like spotify et al? [\#364](https://github.com/mattstratton/castanet/issues/364)
+- Add support for Mastodon for social links \(site, host, and guest\) [\#404](https://github.com/mattstratton/castanet/pull/404) ([mattstratton](https://github.com/mattstratton))
+
+**Fixed bugs:**
+
+- \[BUG\] - readme.md is out of date [\#403](https://github.com/mattstratton/castanet/issues/403)
+
 ## [1.19.0](https://github.com/mattstratton/castanet/tree/1.19.0) (2022-08-10)
 
 **Implemented enhancements:**
@@ -96,7 +118,6 @@
 - Add episode numbers/prefix in RSS and Relevant Titles/Links \[Attempt \#2\] [\#322](https://github.com/mattstratton/castanet/pull/322) ([chrisreddington](https://github.com/chrisreddington))
 - Initial implementation for pronouns [\#312](https://github.com/mattstratton/castanet/pull/312) ([chrisreddington](https://github.com/chrisreddington))
 - Create skeleton of blog feature [\#310](https://github.com/mattstratton/castanet/pull/310) ([mattstratton](https://github.com/mattstratton))
-- Add Functionality: Show next upcoming episode [\#309](https://github.com/mattstratton/castanet/pull/309) ([chrisreddington](https://github.com/chrisreddington))
 
 **Fixed bugs:**
 
@@ -112,6 +133,10 @@
 - Test with matrix build [\#321](https://github.com/mattstratton/castanet/pull/321) ([mattstratton](https://github.com/mattstratton))
 
 ## [1.13.0](https://github.com/mattstratton/castanet/tree/1.13.0) (2020-12-01)
+
+**Implemented enhancements:**
+
+- Add Functionality: Show next upcoming episode [\#309](https://github.com/mattstratton/castanet/pull/309) ([chrisreddington](https://github.com/chrisreddington))
 
 ## [1.12.1](https://github.com/mattstratton/castanet/tree/1.12.1) (2020-12-01)
 
@@ -398,7 +423,7 @@
 
 **Fixed bugs:**
 
-- Sidebar doesn't show if `enable\_jumbo` doesn't exist [\#167](https://github.com/mattstratton/castanet/issues/167)
+- Sidebar doesn't show if `enable_jumbo` doesn't exist [\#167](https://github.com/mattstratton/castanet/issues/167)
 - Grid spills to second page without filling bottom row [\#164](https://github.com/mattstratton/castanet/issues/164)
 - \[Bug\] iTunes/android/Soundcloud subscribe image icons broken [\#155](https://github.com/mattstratton/castanet/issues/155)
 - \[Bug\] stitcher not sticher. Typo in config.toml variable [\#154](https://github.com/mattstratton/castanet/issues/154)

--- a/themes/castanet/README.md
+++ b/themes/castanet/README.md
@@ -8,7 +8,7 @@ If you would like to receive emails when new versions of this theme are released
 
 # Castanet
 
-Castanet is a a Hugo theme for sites that are primarily podcasts. It is heavily influenced by [ado-hugo](//github.com/arresteddevops/ado-hugo) by [Matt Stratton](//github.com/mattstratton).
+Castanet is a Hugo theme for sites that are primarily podcasts. It is heavily influenced by [ado-hugo](//github.com/arresteddevops/ado-hugo) by [Matt Stratton](//github.com/mattstratton).
 
 An example site can be found at http://sample-castanet.netlify.com/
 
@@ -19,7 +19,7 @@ An example site can be found at http://sample-castanet.netlify.com/
 Download the latest version (zip file, not source code) from the [Releases](https://github.com/mattstratton/castanet/releases) page.
 
 
-For more information read the official [setup guide](//gohugo.io/overview/installing/) of Hugo.
+For more information read the official [quick start](//gohugo.io/getting-started/quick-start/) of Hugo.
 
 
 ## Getting started
@@ -36,8 +36,9 @@ This is a completely non-comprehensive list of podcasts that use this theme. Wan
 - [Arrested DevOps](https://www.arresteddevops.com)
 - [Page It to the Limit](https://www.pageittothelimit.com/)
 - [Quiche-Anon](https://quiche-anon.com)
-- [Community Pulse](https://www.communitypulse.io/)
+- [Tech Debt Burndown Podcast](https://techdebtburndown.com/)
 - [The Linux Lemming](https://linuxlemming.com)
+- [The R-Podcast](https://r-podcast.org)
 
 ## Sites inspired by / building upon the Castanet theme
 - [Cloud with Chris](https://www.cloudwithchris.com)

--- a/themes/castanet/REFERENCE.md
+++ b/themes/castanet/REFERENCE.md
@@ -102,7 +102,7 @@ Refer to https://realfavicongenerator.net/ for more details.
 
 ### Social Parameters
 
-These are the social network parameters for your overall site. They should be set under `[params.social]` and all of them allow either the short form (e.g. just your twitter handle) where the theme will construct the URL or the full URL beginning with https://
+These are the social network parameters for your overall site. They should be set under `[params.social]` and all of them allow either the short form (e.g. just your twitter handle) where the theme will construct the URL or the full URL beginning with https:// (with the exception of Mastodon, as that does not have a common url scheme)
 
 | Field Name       | Required | Description                                                                                                      | Example              |
 |------------------|----------|------------------------------------------------------------------------------------------------------------------|----------------------|
@@ -118,6 +118,7 @@ These are the social network parameters for your overall site. They should be se
 | `youtube`        | No       | Name of the YouTube channel.                                                                                     | "arresteddevops"     |
 | `linkedin`       | No       | LinkedIn profile name. This is the part that comes after the `https://www.linkedin.com/in/` in your profile URL. | "mattstratton"       |
 | `twitch`         | No       | Twitch channel/profile for your site. This is the part that comes after `https://twitch.tv/`                     | "mattstratton"       |
+| `mastodon`         | No       | Mastodon account for your site. This needs to be the fully qualified URL including `https`                     | "https://hachyderm.io/@mattstratton"       |
 
 ### Giscus Parameters
 
@@ -171,7 +172,7 @@ You also will set the social parameters (all are optional) under `[params.author
 | `twitch`    | No       | Name of the user's Twitch profile.                                                                               | mattstratton                   |
 | `linkedin`  | No       | LinkedIn profile name. This is the part that comes after the `https://www.linkedin.com/in/` in your profile URL. | "mattstratton"                 |
 | `homepage`  | No       | The user's website, including the `http` at the beginning.                                                       | "https://www.mattstratton.com" |
-
+| `mastodon`  | No       | The user's Mastodon URL, including the `https` at the beginning.                                                       | "https://hachyderm.io/@mattstratton" |
 
 ### Link Parameters
 
@@ -445,6 +446,7 @@ Spoon fresh pie ingredients groceries oranges luncheon farm. Broth chick peas Ch
 | `Instagram` | No       | Instagram profile name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | "mattstratton"                 |
 | `YouTube`   | No       | YouTube profile/channel name                                                                                                                                                                                                                                                                                                                                                                                                                                                                | "mattstratton"                 |
 | `Twitch`   | No       | Twitch profile/channel name                                                                                                                                                                                                                                                                                                                                                                                                                                                                | "mattstratton"                 |
+| `mastodon`  | No       | The user's Mastodon URL, including the `https` at the beginning.                                                       | "https://hachyderm.io/@mattstratton" |
 | `Aka`       | No       | **DEPRECATED - use `guest_group` instead.** The name(s) of another guest file which is an alternate identity for this guest (for example, if the bio changes, name changes, etc). This should be set in both directions (i.e., the `Aka` field should be set on `mstratton.md` and `mstratton2.md` pointing to each other).                                                                                                                                                                                                                | Aka = ["jsmith", "jsmith2"]                   |
 | `guest_group`       | No       | Set to an identifier to mark guests as being different versions of the same person. Only the most recent file in a guest group will appear on the Guests page. Additionally, all members of a guest group will display the same "other episodes" on guest pages.                                                                                                                                                                                                               | "mattstratton"                   |
 

--- a/themes/castanet/archetypes/episode.md
+++ b/themes/castanet/archetypes/episode.md
@@ -5,15 +5,15 @@ PublishDate = {{ .Date }} # this is the datetime for the when the epsiode was pu
 podcast_file = "###.mp3" # the name of the podcast file, after the media prefix.
 podcast_duration = ""
 #podcast_bytes = "" # the length of the episode in bytes
-episode_image = "img/TDB-Logo.jpg"
+episode_image = "img/episode/default.jpg"
 #episode_banner = ""
 #guests = [] # The names of your guests, based on the filename without extension.
 #sponsors = []
 #episode = ""
 title = ""
 #subtitle = ""
-images = ["img/TDB-Logo.jpg"]
-hosts = ["cswan","nselby"] # The names of your hosts, based on the filename without extension.
+images = ["img/episode/default-social.jpg"]
+#hosts = [] # The names of your hosts, based on the filename without extension.
 #aliases = ["/##"]
 #youtube = ""
 explicit = "no" # values are "yes" or "no"
@@ -24,8 +24,3 @@ explicit = "no" # values are "yes" or "no"
 #series = []
 #tags = []
 +++
-**Recording date: Month Day, Year**
-
-*Download at [Apple Podcasts](https://podcastsconnect.apple.com/my-podcasts/the-tech-debt-burndown-podcast/1562710899), [Google Podcasts](https://podcasts.google.com/feed/aHR0cHM6Ly93d3cuc3ByZWFrZXIuY29tL3Nob3cvNDg3MzE4MC9lcGlzb2Rlcy9mZWVk), [Spotify](https://open.spotify.com/show/0t15PUgvQYNWQ6LYXJ8zkz), [iHeartRadio](https://iheart.com/podcast/81137852), [Spreaker](https://www.spreaker.com/show/the-tech-debt-burndown-podcast) or wherever you get your podcasts.*
-
-#### "Pull quote from host or guest." - Speaker ####

--- a/themes/castanet/archetypes/guest.md
+++ b/themes/castanet/archetypes/guest.md
@@ -1,18 +1,18 @@
 +++
 Date = {{ .Date }}
 title = ""
-#Pronouns = ""
+Pronouns = ""
 Twitter = ""
 Website = ""
 Type = "guest"
 Facebook = ""
 Linkedin = ""
 GitHub = ""
-Thumbnail = "img/guest/"
-#Pinterest = ""
-#Instagram = ""
-#YouTube = ""
-#Twitch = ""
+Thumbnail = ""
+Pinterest = ""
+Instagram = ""
+YouTube = ""
+Twitch = ""
 #Aka = []
 #guest_group = ""
 +++

--- a/themes/castanet/layouts/episode/single.html
+++ b/themes/castanet/layouts/episode/single.html
@@ -178,7 +178,12 @@
                     <a href="https://twitch.tv/{{ . }}">
                       <i class="fab fa-twitch fa-2x"></i>
                     </a>
-                  {{- end -}}
+                    {{- end -}}
+                    {{- with .Params.Mastodon -}}
+                    <a href="{{ . }}">
+                      <i class="fab fa-mastodon fa-2x"></i>
+                    </a>
+                    {{- end -}}
                   </div>
                   </div>
                 {{- $.Scratch.Set "guest-exist" "false" -}}
@@ -296,6 +301,11 @@
               {{- with .Params.Twitch -}}
               <a href="https://twitch.tv/{{ . }}">
                 <i class="fab fa-twitch fa-2x"></i>
+              </a>
+            {{- end -}}
+            {{- with .Params.Mastodon -}}
+              <a href="{{ . }}">
+                <i class="fab fa-mastodon fa-2x"></i>
               </a>
             {{- end -}}
             </div>

--- a/themes/castanet/layouts/guest/list.html
+++ b/themes/castanet/layouts/guest/list.html
@@ -69,6 +69,9 @@
             {{ with .Params.Twitch }}
               {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-twitch fa-2x" "prefix" "https://twitch.tv/" "text" "") }}
             {{ end }}
+            {{ with .Params.Mastodon }}
+              {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-mastodon fa-2x" "prefix" "" "text" "") }}
+            {{ end }}
         </div>
       </div>
       {{ end }}

--- a/themes/castanet/layouts/guest/single.html
+++ b/themes/castanet/layouts/guest/single.html
@@ -57,7 +57,10 @@
             {{ end }}
             {{ if .Params.Twitch }}
               {{ partial "social-link.html" (dict "context" .Params.Twitch "aclass" "" "iclass" "fab fa-twitch fa-2x" "prefix" "https://twitch.tv/" "text" "") }}
-          {{ end }}
+            {{ end }}
+            {{ if .Params.Mastodon }}
+              {{ partial "social-link.html" (dict "context" .Params.Mastodon "aclass" "" "iclass" "fab fa-mastodon fa-2x" "prefix" "" "text" "") }}
+            {{ end }}
           </div>
         </div>
       </div>

--- a/themes/castanet/layouts/host/single.html
+++ b/themes/castanet/layouts/host/single.html
@@ -57,6 +57,9 @@
             {{ if .Params.Twitch }}
               {{ partial "social-link.html" (dict "context" .Params.Twitch "iclass" "fab fa-twitch fa-2x" "prefix" "https://twitch.tv/" "text" "") }}
             {{ end }}
+            {{ if .Params.Mastodon }}
+              {{ partial "social-link.html" (dict "context" .Params.Mastodon "iclass" "fab fa-mastodon fa-2x" "prefix" "" "text" "") }}
+            {{ end }}
           </div>
         </div>
       </div>

--- a/themes/castanet/layouts/partials/header.html
+++ b/themes/castanet/layouts/partials/header.html
@@ -76,7 +76,12 @@
         <li>
           {{ partial "social-link.html" (dict "context" $.Site.Params.social.twitch "aclass" "social-links" "iclass" "fab fa-twitch fa-2x" "prefix" "https://twitch.tv/" "text" "") }}
         </li>
-      {{ end }}
+        {{ end }}
+        {{ if (isset .Site.Params.social "mastodon" ) }}
+        <li>
+          {{ partial "social-link.html" (dict "context" $.Site.Params.social.mastodon "aclass" "social-links" "iclass" "fab fa-mastodon fa-2x" "prefix" "" "text" "") }}
+        </li>
+        {{ end }}
       </ul>
   </div>
   </div>

--- a/themes/castanet/layouts/partials/hosts.html
+++ b/themes/castanet/layouts/partials/hosts.html
@@ -50,6 +50,9 @@
               {{ with .Params.Twitch }}
                 {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-twitch fa-2x" "prefix" "https://twitch.tv/") }}
               {{ end }}
+              {{ with .Params.Mastodon }}
+                {{ partial "social-link.html" (dict "context" . "aclass" "" "iclass" "fab fa-mastodon fa-2x" "prefix" "") }}
+              {{ end }}
           </div>
         </div>
         {{- end -}}

--- a/themes/castanet/theme.toml
+++ b/themes/castanet/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/mattstratton/castanet"
 tags = ["podcast", "responsive"]
 features = ["podcast RSS", "subscribe buttons"]
 min_version = "0.69.2"
-theme_version = "1.19.0"
+theme_version = "1.21.5"
 
 [author]
   name = "Matt Stratton"


### PR DESCRIPTION
Latest version of Castanet needed to enable Mastodon links in profiles.

**- What I did**

* Removed Twitter link from profile
* Added Mastodon link
* Updated Castanet to 1.21.5 release

**- Description for the changelog**

feat: Update theme to enable Mastodon links