### PR TITLE
build(deps): Bump Castanet theme to 1.22.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Thanks to [Arrested DevOps](https://www.arresteddevops.com/) for making their [w
 
 ## Editing
 
-1. Install [Hugo](http://gohugo.io) - *NOTE: Please make sure it is at least version 0.74.3*
+1. Install [Hugo](http://gohugo.io) - *NOTE: Please make sure it is at least version 0.161.1*
 2. Clone this repo
 3. If you want to fire up a local copy to see your changes as you go: `hugo server -w --baseUrl="http://localhost:1313"`
 4. You probably want to do the previous thing in another pane/window, as it needs to keep running.

--- a/config.toml
+++ b/config.toml
@@ -5,10 +5,10 @@ theme = "castanet"
 paginate = 9
 
 [permalinks]
-	page = "/:filename/"
-	about = "/:filename/"
-	episode = "/:filename/"
-	redirect = "/:filename"
+	page = "/:contentbasename/"
+	about = "/:contentbasename/"
+	episode = "/:contentbasename/"
+	redirect = "/:contentbasename"
 
 [outputs]
   home = ["HTML", "RSS"]
@@ -54,8 +54,6 @@ media_prefix = "https://api.spreaker.com/v2/episodes/"
 
   [params.social]
     github = "Tech-Debt-Burndown"
-    twitter = "TechDebtPodcast"
-    twitter_domain = "techdebtburndown.com"
     linkedin = "https://www.linkedin.com/groups/12537193/"
 
   [params.authors]

--- a/content/episode/episode3.md
+++ b/content/episode/episode3.md
@@ -34,7 +34,7 @@ explicit = "no" # values are "yes" or "no"
 This is a common question, and Chris and Nick discovered that they do it differently. 
 
 Chris describes how he views tech debt from the perspective of his continuous integration and continuous delivery pipeline: “How quickly can I release, and what’s getting in my way?” He discussed that recently, [Charity Majors](https://twitter.com/mipsytipsy) has been discussing the importance of a quick feedback cycle for developers:
-{{< tweet user="mipsytipsy" id="1382619734781272066" >}}
+{{< x user="mipsytipsy" id="1382619734781272066" >}}
 
 Basically, this comes down to, ‘you’ve got 15 minutes to build’ in order to be good at this, and this brings us to the [Theory of Constraints](https://en.wikipedia.org/wiki/Theory_of_constraints "The theory of constraints (TOC) is a management paradigm that views any manageable system as being limited in achieving more of its goals by a very small number of constraints. - Wikipedia") thing: what things are blocking me from getting to that 15-minute build time, and how do I get rid of them? 
 

--- a/content/episode/episode4.md
+++ b/content/episode/episode4.md
@@ -59,7 +59,7 @@ Chris points out that this makes sense: those programs mentioned in having a pos
 Wendy is quite sensitive to the idea that the two practices identified as most likely to correlate to better outcomes, Proactive Tech Refresh and Well Integrated Technology, are of course seen by the more skeptical of us to have been directly driven by the fact that Cisco is a vendor of that stuff. Wendy insists (and Wade has insisted) that the double-blind nature of the survey administration and the analysis means that it actually was independently learned, not sponsored. We believe it. Wade tweeted about it recently:
 
 
-{{< tweet user="wadebaker" id="1386029061273751552" >}}
+{{< x user="wadebaker" id="1386029061273751552" >}}
 
 Also, the survey didn't ask, 'Do you think buying new stuff makes stuff better?' they asked separate questions. The correlations were stronger than they thought. 
 

--- a/content/episode/episode5.md
+++ b/content/episode/episode5.md
@@ -48,7 +48,7 @@ Chris spent a bunch of time recently looking at Chaos engineering and how to int
 
 What Chris sees in the bottom 50% of companies is related to a [Charity Majors](https://twitter.com/mipsytipsy/status/1270676644965957633) comment that they have the engine underwater and they have to work ever harder to see that they need to do something to drain the water that is flooding you. 
 
-{{< tweet user="mipsytipsy" id="1270676644965957633" >}}
+{{< x user="mipsytipsy" id="1270676644965957633" >}}
 
 When technical people have to talk to non-technical people about this, people who are smart but don't see the tradeoffs in feature development, the non-tech people don't understand the tradeoffs. Not that they don't want to understand, but that they don't see it. so the quest for metrics is really about finding Indicators Of Tech Debt. 
 

--- a/content/episode/episode8.md
+++ b/content/episode/episode8.md
@@ -37,7 +37,7 @@ Nick and Chris are joined by Olivier Jacques, a Distinguished Technologist at DX
 
 Olivier thinks that policy debt, technical debt, security, debt, infrastructure, debt, and other debt types are something that must be paid attention to, but he was wondering why we don’t seem to have the time to address them  - we are either too busy, or we don't have the management support, or sometimes we don't even know where to start and what do we improve. So he set out to write up some strategies he feels will help. 
 
-{{< tweet user="ojacques2" id="1390075907805700097" >}}
+{{< x user="ojacques2" id="1390075907805700097" >}}
 
 We don't easily know where to start, but he thinks where he saw the biggest struggle was perhaps in explaining to management and leadership what it meant to reduce tech debt, and how to organize a team to make sure that ted debt is not something put on the back burner and forgotten. 
 

--- a/themes/castanet/CHANGELOG.md
+++ b/themes/castanet/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 
-## [1.22.15](https://github.com/mattstratton/castanet/tree/1.22.15) (2025-05-21)
+## [v2.0.0-beta.9](https://github.com/mattstratton/castanet/tree/v2.0.0-beta.9) (2025-05-28)
+
+## [v2.0.0-beta.8](https://github.com/mattstratton/castanet/tree/v2.0.0-beta.8) (2025-05-28)
+
+## [v2.0.0-beta.7](https://github.com/mattstratton/castanet/tree/v2.0.0-beta.7) (2025-05-27)
+
+**Fixed bugs:**
+
+- \[BUG\] - Youtube is cropped weird in row layout when "latest episode" has a video [\#490](https://github.com/mattstratton/castanet/issues/490)
+- Inline links in grey theme are really hard to distinguish [\#99](https://github.com/mattstratton/castanet/issues/99)
+
+**Closed issues:**
+
+- Document the search feature [\#476](https://github.com/mattstratton/castanet/issues/476)
+- \[EPIC\] Refactor comment system and other options [\#421](https://github.com/mattstratton/castanet/issues/421)
+
+## [v2.0.0-beta.6](https://github.com/mattstratton/castanet/tree/v2.0.0-beta.6) (2025-05-23)
+
+**Implemented enhancements:**
+
+- Ensure that all Open Graph tags are being used [\#170](https://github.com/mattstratton/castanet/issues/170)
+
+**Closed issues:**
+
+- Update references to iTunes to be Apple Podcasts instead [\#481](https://github.com/mattstratton/castanet/issues/481)
+
+## [v1.22.15](https://github.com/mattstratton/castanet/tree/v1.22.15) (2025-05-21)
 
 **Implemented enhancements:**
 

--- a/themes/castanet/README.md
+++ b/themes/castanet/README.md
@@ -33,6 +33,7 @@ If you would like to help make improvements or fixes to this theme, please see [
 
 ## Sites using the Castanet theme
 This is a completely non-comprehensive list of podcasts that use this theme. Want to add your site? Submit a pull request against the README file!
+- [Armenian News Network / Groong Podcast](https://podcasts.groong.org/)
 - [Arrested DevOps](https://www.arresteddevops.com)
 - [Page It to the Limit](https://www.pageittothelimit.com/)
 - [Quiche-Anon](https://quiche-anon.com)

--- a/themes/castanet/layouts/_default/baseof.html
+++ b/themes/castanet/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html itemscope lang="{{ .Site.LanguageCode }}">
+<html itemscope lang="{{ .Site.Language.Locale }}">
 <head>
 {{ partial "head.html" . }}
 </head>

--- a/themes/castanet/layouts/_default/blog.rss.xml
+++ b/themes/castanet/layouts/_default/blog.rss.xml
@@ -3,10 +3,10 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink  }}</link>
     <description>Recent blogs {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
@@ -15,7 +15,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | htmlEscape }}</description>
     </item>

--- a/themes/castanet/layouts/_default/episode.rss.xml
+++ b/themes/castanet/layouts/_default/episode.rss.xml
@@ -17,7 +17,7 @@
     <lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" .Date }}</lastBuildDate>
     <sy:updatePeriod>hourly</sy:updatePeriod>
     <sy:updateFrequency>1</sy:updateFrequency>
-    <language>{{ .Site.Params.feed.language | default .Site.LanguageCode }}</language>
+    <language>{{ .Site.Params.feed.language | default .Site.Language.Locale }}</language>
     <copyright>{{ .Site.Params.feed.copyright }}</copyright>
     {{ with .Site.Params.feed.itunes_subtitle }}<itunes:subtitle>{{ . }}</itunes:subtitle>{{ end }}
     <itunes:author>{{ .Site.Params.feed.itunes_author }}</itunes:author>

--- a/themes/castanet/layouts/blog/section.rss.xml
+++ b/themes/castanet/layouts/blog/section.rss.xml
@@ -3,10 +3,10 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink  }}</link>
     <description>Recent blogs {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
@@ -15,7 +15,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | htmlEscape }}</description>
     </item>

--- a/themes/castanet/layouts/episode/section.rss.xml
+++ b/themes/castanet/layouts/episode/section.rss.xml
@@ -17,7 +17,7 @@
     <lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" .Date }}</lastBuildDate>
     <sy:updatePeriod>hourly</sy:updatePeriod>
     <sy:updateFrequency>1</sy:updateFrequency>
-    <language>{{ .Site.Params.feed.language | default .Site.LanguageCode }}</language>
+    <language>{{ .Site.Params.feed.language | default .Site.Language.Locale }}</language>
     <copyright>{{ .Site.Params.feed.copyright }}</copyright>
     {{ with .Site.Params.feed.itunes_subtitle }}<itunes:subtitle>{{ . }}</itunes:subtitle>{{ end }}
     <itunes:author>{{ .Site.Params.feed.itunes_author }}</itunes:author>

--- a/themes/castanet/layouts/section/blog.rss.xml
+++ b/themes/castanet/layouts/section/blog.rss.xml
@@ -3,10 +3,10 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink  }}</link>
     <description>Recent blogs {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     <atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />
@@ -15,7 +15,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.author.email }}<author>{{.}}{{ with $.Site.Params.author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | htmlEscape }}</description>
     </item>

--- a/themes/castanet/layouts/section/episode.rss.xml
+++ b/themes/castanet/layouts/section/episode.rss.xml
@@ -17,7 +17,7 @@
     <lastBuildDate>{{ dateFormat "Mon, 2 Jan 2006 15:04:05 -0700" .Date }}</lastBuildDate>
     <sy:updatePeriod>hourly</sy:updatePeriod>
     <sy:updateFrequency>1</sy:updateFrequency>
-    <language>{{ .Site.Params.feed.language | default .Site.LanguageCode }}</language>
+    <language>{{ .Site.Params.feed.language | default .Site.Language.Locale }}</language>
     <copyright>{{ .Site.Params.feed.copyright }}</copyright>
     {{ with .Site.Params.feed.itunes_subtitle }}<itunes:subtitle>{{ . }}</itunes:subtitle>{{ end }}
     <itunes:author>{{ .Site.Params.feed.itunes_author }}</itunes:author>


### PR DESCRIPTION
Needed newer theme to get onto latest Hugo (0.161.1)

**- What I did**

* 1.22.16 of Castanet
* Content changes to adapt to deprecations
* README update

**- How I did it**

```sh
git checkout main
git pull
git checkout -b cpswan-bump-castanet-1.22.16
cd themes/
wget https://github.com/mattstratton/castanet/releases/download/1.22.16/castanet-1.22.16.zip
cd castanet
unzip ../castanet-1.22.16.zip
rm ../castanet-1.22.16.zip
git add .
git commit -m 'build(deps): Bump Castanet theme to 1.22.16'
git push
```

**- How to verify it**

:eyes: https://55e44c6e.cloudflarepages-wwn1.pages.dev/

**- Description for the changelog**

[build(deps): Bump Castanet theme to 1.22.16](https://github.com/Tech-Debt-Burndown/TDBwebsite/commit/1b65f92199773f9b09733cb95970567776d7934f)